### PR TITLE
일감 정보 확인 API userId -> applicationId로 변경 및 personnel 필드값 삭제

### DIFF
--- a/src/main/java/com/sharework/controller/JobController.java
+++ b/src/main/java/com/sharework/controller/JobController.java
@@ -136,10 +136,10 @@ public class JobController {
 
     @ApiResponses({@ApiResponse(code = 200, message = "SUCCESS", response = JobHiredInfo.class),
             @ApiResponse(code = 404, message = "NOT FOUND", response = ErrorResponse.class)})
-    @GetMapping(value = "hired/info/{jobId}/approve/{userId}", produces = {MediaType.APPLICATION_JSON_VALUE})
+    @GetMapping(value = "hired/info/{jobId}/approve/{applicationId}", produces = {MediaType.APPLICATION_JSON_VALUE})
     @ApiOperation(httpMethod = "GET", value = "일감 정보 확인")
-    public ResponseEntity getJobHIredInfo(@PathVariable long jobId, @PathVariable long userId){
-        return jobService.getJobHiredInfo(jobId, userId);
+    public ResponseEntity getJobHIredInfo(@PathVariable long jobId, @PathVariable long applicationId){
+        return jobService.getJobHiredInfo(jobId, applicationId);
     }
 
 }

--- a/src/main/java/com/sharework/response/model/job/JobHiredInfoPayload.java
+++ b/src/main/java/com/sharework/response/model/job/JobHiredInfoPayload.java
@@ -20,20 +20,18 @@ public class JobHiredInfoPayload {
     private LocalDateTime endAt;
     private String address;
     private String addressDetail;
-    private long personnel;
     private String contents;
     private List<String> jobTagList;
     private WorkerNameAndPhoneNumber workerNameAndPhoneNumber;
     private GiverNameAndPhoneNumber giverNameAndPhoneNumber;
 
     @Builder
-    public JobHiredInfoPayload(String title, LocalDateTime startAt, LocalDateTime endAt, String address, String addressDetail, long personnel, String contents, List<String> jobTagList, WorkerNameAndPhoneNumber workerNameAndPhoneNumber, GiverNameAndPhoneNumber giverNameAndPhoneNumber) {
+    public JobHiredInfoPayload(String title, LocalDateTime startAt, LocalDateTime endAt, String address, String addressDetail, String contents, List<String> jobTagList, WorkerNameAndPhoneNumber workerNameAndPhoneNumber, GiverNameAndPhoneNumber giverNameAndPhoneNumber) {
         this.title = title;
         this.startAt = startAt;
         this.endAt = endAt;
         this.address = address;
         this.addressDetail = addressDetail;
-        this.personnel = personnel;
         this.contents = contents;
         this.jobTagList = jobTagList;
         this.workerNameAndPhoneNumber = workerNameAndPhoneNumber;
@@ -47,7 +45,6 @@ public class JobHiredInfoPayload {
                 .endAt(job.getEndAt())
                 .address(job.getAddress())
                 .addressDetail(job.getAddressDetail())
-                .personnel(job.getPersonnel())
                 .contents(job.getContents())
                 .jobTagList(jobTagList.stream().map(JobTag::getContents).collect(Collectors.toList()))
                 .workerNameAndPhoneNumber(WorkerNameAndPhoneNumber.builder()

--- a/src/main/java/com/sharework/service/JobService.java
+++ b/src/main/java/com/sharework/service/JobService.java
@@ -602,7 +602,7 @@ public class JobService {
         return response;
     }
 
-    public ResponseEntity getJobHiredInfo(long jobId, long userId) {
+    public ResponseEntity getJobHiredInfo(long jobId, long applicationId) {
         ResponseEntity response = null;
         Response error = null;
 
@@ -617,7 +617,8 @@ public class JobService {
 
         Job job = jobOptional.get();
         List<JobTag> jobTagList = jobTagDao.findByJobId(job.getId());
-        User worker = userDao.findById(userId).get();
+        long workerId = applicationDao.findById(applicationId).get().getUserId();
+        User worker = userDao.findById(workerId).get();
         User giver = userDao.findById(job.getUserId()).get();
 
         JobHiredInfo jobHiredInfo = JobHiredInfo.builder()


### PR DESCRIPTION
일감정보 확인에 대해서 오류가 있어서 해당 부분 피드백 받아서 수정했습니다.
기버입장에서만 생각해서 만든 API 였는데 워커 입장에서는 사용할 수 없었기 때문에 수정을 진행했습니다.

- 일감 정보 확인 API 응답값에 personnel 기획상 필요없다는 하셔서 삭제
- 일감 정보 확인 API userId가 아닌 applicationId로 받도록 변경