### PR TITLE
Rename and Cleanup regex for nickname

### DIFF
--- a/src/main/java/com/sharework/request/model/SignupRequestPw.java
+++ b/src/main/java/com/sharework/request/model/SignupRequestPw.java
@@ -20,10 +20,9 @@ public class SignupRequestPw {
     @NotNull
     private String email;
 
-    @ApiModelProperty(value = "name", position = 2, example = "8~20글자 사이로 영어한글숫자가능", required = true)
+    @ApiModelProperty(value = "name", position = 2, example = "1~6글자 사이로 영어한글숫자가능", required = true)
     @NotNull
-    @Pattern(regexp = "^[가-힣a-zA-Z0-9]*$")
-    @Size(min = 8, max = 20, message = "닉네임을 8~20자 사이로 입력해주세요.")
+    @Pattern(regexp = "^[가-힣a-zA-Z0-9]{1,6}$")
     private String name;
 
     @ApiModelProperty(value = "phoneNumber", position = 3, example = "01012345678", required = true)

--- a/src/main/java/com/sharework/service/UserService.java
+++ b/src/main/java/com/sharework/service/UserService.java
@@ -214,7 +214,7 @@ public class UserService {
         return response;
     }
 
-    public ResponseEntity checkNickname(String nickName) {
+    public ResponseEntity checkNickname(String nickname) {
 
         ResponseEntity response = null;
         ErrorResponse error = null;
@@ -222,7 +222,7 @@ public class UserService {
         BasicMeta meta;
 
 
-        if (!Pattern.matches("^[가-힣a-zA-Z0-9]{1,6}$", nickName)) {
+        if (!Pattern.matches("^[가-힣a-zA-Z0-9]{1,6}$", nickname)) {
             errorMsg = "사용 불가능한 닉네임입니다.";
             meta = new BasicMeta(false, errorMsg);
             error = new ErrorResponse(meta);
@@ -230,7 +230,7 @@ public class UserService {
             return response;
         }
 
-        if (userDao.existsByNameAndDeleteYn(nickName, "N")) {
+        if (userDao.existsByNameAndDeleteYn(nickname, "N")) {
             errorMsg = "닉네임이 존재합니다.";
             meta = new BasicMeta(false, errorMsg);
             error = new ErrorResponse(meta);


### PR DESCRIPTION
이전 저장소에서 진행 중 이었던 https://github.com/sharework-kr/Sharework-Back-end/pull/162 정리합니다
- 아래에서도 사용하고 있는 중복된 정규표현식을 동일하게 정리
https://github.com/backcamp/sharework-api/blob/d9a0b3498b297d03e886042a8b5a92991f067ae0/src/main/java/com/sharework/service/UserService.java#L225
- 불필요한 camelcase 변수명 재지정