### PR TITLE
Add checklist and tags for getPreviousJobs

### DIFF
--- a/src/main/java/com/sharework/response/model/job/APIPreviousJobs.java
+++ b/src/main/java/com/sharework/response/model/job/APIPreviousJobs.java
@@ -65,8 +65,10 @@ public class APIPreviousJobs {
 
         public List<String> checklist;
 
+        public List<String> tags;
+
         public Job(String title, LocalDateTime startAt, LocalDateTime endAt, String payType, Integer pay, String contents, LocalDateTime createdAt, double lat, double lng,
-                   String addressDetail, List<String> checklist) {
+                   String addressDetail, List<String> checklist, List<String> tags) {
             this.title = title;
             this.startAt = startAt;
             this.endAt = endAt;
@@ -78,6 +80,7 @@ public class APIPreviousJobs {
             this.lng = lng;
             this.addressDetail = addressDetail;
             this.checklist = checklist;
+            this.tags = tags;
         }
     }
 

--- a/src/main/java/com/sharework/response/model/job/APIPreviousJobs.java
+++ b/src/main/java/com/sharework/response/model/job/APIPreviousJobs.java
@@ -66,8 +66,10 @@ public class APIPreviousJobs {
         @Column(name = "jobBenefits")
         public List<JobBenefit> jobBenefits;
 
+        public List<String> checklist;
+
         public Job(String title, LocalDateTime startAt, LocalDateTime endAt, String payType, Integer pay, String contents, LocalDateTime createdAt, double lat, double lng,
-                   String addressDetail, List<JobBenefit> jobBenefits) {
+                   String addressDetail, List<JobBenefit> jobBenefits, List<String> checklist) {
             this.title = title;
             this.startAt = startAt;
             this.endAt = endAt;
@@ -79,6 +81,7 @@ public class APIPreviousJobs {
             this.lng = lng;
             this.addressDetail = addressDetail;
             this.jobBenefits = jobBenefits;
+            this.checklist = checklist;
         }
     }
 

--- a/src/main/java/com/sharework/response/model/job/APIPreviousJobs.java
+++ b/src/main/java/com/sharework/response/model/job/APIPreviousJobs.java
@@ -7,7 +7,6 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.Column;
-import javax.persistence.Id;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -15,22 +14,22 @@ import java.util.List;
 @NoArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class APIPreviousJobs {
-    public APIPreviousJobs(Payload payload, BasicMeta meta) {
+    public APIPreviousJobs(JobPreviousPayload payload, BasicMeta meta) {
         this.payload = payload;
         this.meta = meta;
     }
 
     @ApiModelProperty(value = "payload", position = 1)
-    public Payload payload;
+    public JobPreviousPayload payload;
 
     @ApiModelProperty(value = "meta", position = 2)
     public BasicMeta meta;
 
-    public static class Payload {
+    public static class JobPreviousPayload {
         @ApiModelProperty(value = "jobs")
         public List<Job> jobs;
 
-        public Payload(List<Job> jobs) {
+        public JobPreviousPayload(List<Job> jobs) {
             this.jobs = jobs;
         }
     }

--- a/src/main/java/com/sharework/response/model/job/APIPreviousJobs.java
+++ b/src/main/java/com/sharework/response/model/job/APIPreviousJobs.java
@@ -63,13 +63,10 @@ public class APIPreviousJobs {
 
         public String addressDetail;
 
-        @Column(name = "jobBenefits")
-        public List<JobBenefit> jobBenefits;
-
         public List<String> checklist;
 
         public Job(String title, LocalDateTime startAt, LocalDateTime endAt, String payType, Integer pay, String contents, LocalDateTime createdAt, double lat, double lng,
-                   String addressDetail, List<JobBenefit> jobBenefits, List<String> checklist) {
+                   String addressDetail, List<String> checklist) {
             this.title = title;
             this.startAt = startAt;
             this.endAt = endAt;
@@ -80,7 +77,6 @@ public class APIPreviousJobs {
             this.lat = lat;
             this.lng = lng;
             this.addressDetail = addressDetail;
-            this.jobBenefits = jobBenefits;
             this.checklist = checklist;
         }
     }

--- a/src/main/java/com/sharework/service/JobService.java
+++ b/src/main/java/com/sharework/service/JobService.java
@@ -20,6 +20,7 @@ import com.sharework.response.model.job.APIProceedingList.JobProceedingPayload;
 import com.sharework.response.model.job.APIProceedingList.ProceedingJob;
 import com.sharework.response.model.meta.BasicMeta;
 import com.sharework.response.model.user.Giver;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -452,9 +453,16 @@ public class JobService {
                 responseBenefits.add(new APIPreviousJobs.JobBenefit(baseJobBenefit.get().getContents()));
             }
 
+            List<JobCheckList> checklist = jobCheckListDao.findByJobId(job.getId());
+            // List<String> checklistContents = checklist.stream().map(JobCheckList::getContents).collect(Collectors.toList());
+            List<String> checklistContents = new ArrayList<>();
+            for (JobCheckList jobCheckList : checklist) {
+                checklistContents.add(jobCheckList.getContents());
+            }
+
             Optional<APIPreviousJobs.Job> responseJob = Optional.of(new APIPreviousJobs.Job(
                     job.getTitle(), job.getStartAt(), job.getEndAt(), job.getPayType(), job.getPay(), job.getContents(),
-                    job.getCreatedAt(), job.getLat(), job.getLng(), job.getAddressDetail(), responseBenefits));
+                    job.getCreatedAt(), job.getLat(), job.getLng(), job.getAddressDetail(), responseBenefits, checklistContents));
 
             responseJobs.add(responseJob.get());
         }

--- a/src/main/java/com/sharework/service/JobService.java
+++ b/src/main/java/com/sharework/service/JobService.java
@@ -15,12 +15,11 @@ import com.sharework.response.model.job.*;
 import com.sharework.response.model.job.APICompletedList.CompletedJob;
 import com.sharework.response.model.job.APICompletedList.JobCompletedPayload;
 import com.sharework.response.model.job.APIPreviousJobs.JobPreviousPayload;
-import com.sharework.response.model.job.APIProceedingList.Groupstatus;
 import com.sharework.response.model.job.APIProceedingList.JobProceedingPayload;
 import com.sharework.response.model.job.APIProceedingList.ProceedingJob;
 import com.sharework.response.model.meta.BasicMeta;
 import com.sharework.response.model.user.Giver;
-import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;

--- a/src/main/java/com/sharework/service/JobService.java
+++ b/src/main/java/com/sharework/service/JobService.java
@@ -14,6 +14,7 @@ import com.sharework.response.model.*;
 import com.sharework.response.model.job.*;
 import com.sharework.response.model.job.APICompletedList.CompletedJob;
 import com.sharework.response.model.job.APICompletedList.JobCompletedPayload;
+import com.sharework.response.model.job.APIPreviousJobs.JobPreviousPayload;
 import com.sharework.response.model.job.APIProceedingList.Groupstatus;
 import com.sharework.response.model.job.APIProceedingList.JobProceedingPayload;
 import com.sharework.response.model.job.APIProceedingList.ProceedingJob;
@@ -458,7 +459,7 @@ public class JobService {
             responseJobs.add(responseJob.get());
         }
 
-        APIPreviousJobs.Payload payload = new APIPreviousJobs.Payload(responseJobs);
+        JobPreviousPayload payload = new JobPreviousPayload(responseJobs);
         BasicMeta meta = new BasicMeta(true, "");
 
         response = new ResponseEntity<>(new APIPreviousJobs(payload, meta), HttpStatus.OK);

--- a/src/main/java/com/sharework/service/JobService.java
+++ b/src/main/java/com/sharework/service/JobService.java
@@ -451,9 +451,15 @@ public class JobService {
                 checklistContents.add(jobCheckList.getContents());
             }
 
+            List<JobTag> jobTag = jobTagDao.findByJobId(job.getId());
+            List<String> jobTagContents = new ArrayList<>();
+            for (JobTag tag : jobTag) {
+                jobTagContents.add(tag.getContents());
+            }
+
             Optional<APIPreviousJobs.Job> responseJob = Optional.of(new APIPreviousJobs.Job(
                     job.getTitle(), job.getStartAt(), job.getEndAt(), job.getPayType(), job.getPay(), job.getContents(),
-                    job.getCreatedAt(), job.getLat(), job.getLng(), job.getAddressDetail(), checklistContents));
+                    job.getCreatedAt(), job.getLat(), job.getLng(), job.getAddressDetail(), checklistContents, jobTagContents));
 
             responseJobs.add(responseJob.get());
         }

--- a/src/main/java/com/sharework/service/JobService.java
+++ b/src/main/java/com/sharework/service/JobService.java
@@ -444,11 +444,11 @@ public class JobService {
         List<Job> jobs = jobDao.findTop10ByUserIdOrderByIdDesc(userId); // 상위 10개 공고
 
         for (Job job : jobs) {
-            List<JobCheckList> checklist = jobCheckListDao.findByJobId(job.getId());
+            List<JobCheckList> jobChecklist = jobCheckListDao.findByJobId(job.getId());
             // List<String> checklistContents = checklist.stream().map(JobCheckList::getContents).collect(Collectors.toList());
-            List<String> checklistContents = new ArrayList<>();
-            for (JobCheckList jobCheckList : checklist) {
-                checklistContents.add(jobCheckList.getContents());
+            List<String> jobChecklistContents = new ArrayList<>();
+            for (JobCheckList checklist : jobChecklist) {
+                jobChecklistContents.add(checklist.getContents());
             }
 
             List<JobTag> jobTag = jobTagDao.findByJobId(job.getId());
@@ -459,7 +459,7 @@ public class JobService {
 
             Optional<APIPreviousJobs.Job> responseJob = Optional.of(new APIPreviousJobs.Job(
                     job.getTitle(), job.getStartAt(), job.getEndAt(), job.getPayType(), job.getPay(), job.getContents(),
-                    job.getCreatedAt(), job.getLat(), job.getLng(), job.getAddressDetail(), checklistContents, jobTagContents));
+                    job.getCreatedAt(), job.getLat(), job.getLng(), job.getAddressDetail(), jobChecklistContents, jobTagContents));
 
             responseJobs.add(responseJob.get());
         }

--- a/src/main/java/com/sharework/service/JobService.java
+++ b/src/main/java/com/sharework/service/JobService.java
@@ -444,15 +444,6 @@ public class JobService {
         List<Job> jobs = jobDao.findTop10ByUserIdOrderByIdDesc(userId); // 상위 10개 공고
 
         for (Job job : jobs) {
-
-            // 제공사항
-            List<JobBenefit> benefits = jobBenefitDao.findByJobId(job.getId());
-            List<APIPreviousJobs.JobBenefit> responseBenefits = new ArrayList<>();
-            for (JobBenefit benefit : benefits) {
-                Optional<BaseBenefit> baseJobBenefit = baseBenefitDao.findById(benefit.getBaseBenefitId());
-                responseBenefits.add(new APIPreviousJobs.JobBenefit(baseJobBenefit.get().getContents()));
-            }
-
             List<JobCheckList> checklist = jobCheckListDao.findByJobId(job.getId());
             // List<String> checklistContents = checklist.stream().map(JobCheckList::getContents).collect(Collectors.toList());
             List<String> checklistContents = new ArrayList<>();
@@ -462,7 +453,7 @@ public class JobService {
 
             Optional<APIPreviousJobs.Job> responseJob = Optional.of(new APIPreviousJobs.Job(
                     job.getTitle(), job.getStartAt(), job.getEndAt(), job.getPayType(), job.getPay(), job.getContents(),
-                    job.getCreatedAt(), job.getLat(), job.getLng(), job.getAddressDetail(), responseBenefits, checklistContents));
+                    job.getCreatedAt(), job.getLat(), job.getLng(), job.getAddressDetail(), checklistContents));
 
             responseJobs.add(responseJob.get());
         }


### PR DESCRIPTION
https://sharework101.atlassian.net/browse/SW-756
이전일감 등록시 체크리스트 관련하여 수정합니다

- JobPreviousPayload 으로 이름을 변경하여, 스웨거에 잘못된 표시를 정정합니다 (참고: https://github.com/sharework-kr/Sharework-Back-end/pull/145)
- 문자열 배열 값을 갖는 `checklist` 와 `tags` 필드를 일감 체크리스트를 추가합니다
- 클라팀과 확인 후 사용하지 않는 `responseBenefits` 필드를 제거합니다