### PR TITLE
Add feature slack alerts for dev

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -46,6 +46,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
+          file: Dockerfile.dev
           push: true
           tags: |
             ghcr.io/${{ github.repository }}:${{ env.tag }}

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,9 @@
+FROM openjdk:11
+
+VOLUME /tmp
+ENV TZ Asia/Seoul
+EXPOSE 8080
+ARG JAR_FILE=build/libs/ShareWork-0.0.1-SNAPSHOT.jar
+COPY ${JAR_FILE} app.jar
+
+ENTRYPOINT ["java", "-jar", "/app.jar", "--spring.profiles.active=dev"]

--- a/build.gradle
+++ b/build.gradle
@@ -93,6 +93,9 @@ dependencies {
 
 	//sms인증문자API
 	implementation group: 'net.nurigo', name: 'javaSDK', version: '2.2'
+
+	// slack for errors
+	implementation group: 'com.github.maricn', name: 'logback-slack-appender', version: '1.6.1'
 }
 
 test {

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+    <springProperty name="SLACK_WEBHOOK_URI" source="logging.slack.webhook-uri"/>
+
+    <appender name="SLACK" class="com.github.maricn.logback.SlackAppender">
+        <webhookUri>${SLACK_WEBHOOK_URI}</webhookUri>
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} ${HOSTNAME} %-5level --- %msg %n</pattern>
+        </layout>
+        <username>Errors and Warnings</username>
+        <iconEmoji>:rotating_light:</iconEmoji>
+        <colorCoding>true</colorCoding>
+    </appender>
+
+    <appender name="ASYNC_SLACK" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="SLACK"/>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+            <level>WARN</level>
+        </filter>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <springProfile name="dev">
+            <appender-ref ref="ASYNC_SLACK"/>
+        </springProfile>
+    </root>
+</configuration>


### PR DESCRIPTION
- 운영 및 모니터링을 위해,
- 개발(테스트)서버 환경에 오류와 경고 메시지를 슬랙에 연동합니다
- 이를 위해 새로운 _application-dev.yml_ 프로파일과 함께 _Dockerfile.dev_ 추가합니다 
    - [x] 리뷰 & 머지 https://github.com/backcamp/sharework-profiles/pull/1 
- 로컬 환경에서는 위 기능이 포함되지 않습니다
    - 로컬 환경: 
       - _application.yml_
       -  _Dockerfile_ 
    - 개발(테스트) 환경: 
       - _application-dev.yml_
       - _Dockerfile.dev_ 

<img width="2071" alt="Screenshot 2023-10-01 at 5 47 10 AM" src="https://github.com/backcamp/sharework-api/assets/30719956/cc90f140-3355-4155-b619-03d95a1164d2">
