### PR TITLE
Add checkNickname test and JaCoCo plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'org.springframework.boot' version '2.5.3'
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 	id 'java'
+	id 'jacoco'
 }
 
 group = 'com.sharework'
@@ -100,6 +101,11 @@ dependencies {
 
 test {
 	useJUnitPlatform()
+	finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+	dependsOn test
 }
 
 sourceSets {

--- a/src/test/java/com/sharework/service/UserServiceTest.java
+++ b/src/test/java/com/sharework/service/UserServiceTest.java
@@ -1,0 +1,37 @@
+package com.sharework.service;
+
+import com.sharework.response.model.SuccessResponse;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class UserServiceTest {
+
+    @Autowired
+    UserService userService;
+
+    @Test
+    void checkNickname() {
+        String failNickname = "";
+        SuccessResponse response = userService.checkNickname(failNickname);
+        Assertions.assertFalse(response.getMeta().isStatus());
+
+        failNickname = "1234567";
+        response = userService.checkNickname(failNickname);
+        Assertions.assertFalse(response.getMeta().isStatus());
+
+        failNickname = "@";
+        response = userService.checkNickname(failNickname);
+        Assertions.assertFalse(response.getMeta().isStatus());
+
+        failNickname = "테트테스트여";  // Already registered.
+        response = userService.checkNickname(failNickname);
+        Assertions.assertFalse(response.getMeta().isStatus());
+
+        String passNickname = "강남바리스타";
+        response = userService.checkNickname(passNickname);
+        Assertions.assertTrue(response.getMeta().isStatus());
+    }
+}


### PR DESCRIPTION
- checkNickname 시작으로 유닛테스트를 도입합니다
- 이와 함께 [JaCoCo 플러그인](https://docs.gradle.org/current/userguide/jacoco_plugin.html#jacoco_plugin)을 추가하여 커버리지를 확인합니다
- 커버리지 리포트는 테스트 또는 빌드 실행 이후 생성됩니다 - _build/reports/jacoco/test/html/index.html_
![Screenshot 2023-10-16 at 12 47 48 AM](https://github.com/backcamp/sharework-api/assets/30719956/6c6aba1a-7d95-4e38-89e5-bc7bf5a9a9c2)

