### PR TITLE
Fix fcm path to ClassPathResource

### DIFF
--- a/src/main/java/com/sharework/config/FirebaseConfig.java
+++ b/src/main/java/com/sharework/config/FirebaseConfig.java
@@ -3,13 +3,13 @@ package com.sharework.config;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
 
 @Slf4j
 @Configuration
@@ -21,10 +21,10 @@ public class FirebaseConfig {
     @Bean
     public void initializeFirebase() {
         try {
-            FileInputStream serviceAccount = new FileInputStream(path);
+            ClassPathResource resource = new ClassPathResource(path);
 
             FirebaseOptions options = FirebaseOptions.builder()
-                .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                .setCredentials(GoogleCredentials.fromStream(resource.getInputStream()))
                 .build();
 
             FirebaseApp firebaseApp = FirebaseApp.initializeApp(options);


### PR DESCRIPTION
- 로컬 테스트시 문제 없었으나, JAR 추출 후 다음 오류가 발생하여, ClassPathResource 를 사용하여 대응합니다 
- 연계된 PR: https://github.com/backcamp/sharework-profiles/pull/3 머지 되면, 추가 커밋 하겠습니다

```
ERROR --- initializeFirebase FileNotFoundException: java.io.FileNotFoundException: sharework-profiles/sharework-be18f-firebase-adminsdk-3q9ih-ca2f5f9b71.json (No such file or directory)
```

```
ERROR --- Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Request processing failed; nested exception is java.lang.IllegalStateException: FirebaseApp with name [DEFAULT] doesn't exist. ] with root cause

java.lang.IllegalStateException: FirebaseApp with name [DEFAULT] doesn't exist.
    at com.google.firebase.FirebaseApp.getInstance(FirebaseApp.java:161)
    at com.google.firebase.FirebaseApp.getInstance(FirebaseApp.java:132)
    at com.google.firebase.messaging.FirebaseMessaging.getInstance(FirebaseMessaging.java:64)
    at com.sharework.service.AlarmService.sendAlarm(AlarmService.java:57)
```    