### PR TITLE
Add prod CICD

### DIFF
--- a/.github/workflows/cicd-prod.yml
+++ b/.github/workflows/cicd-prod.yml
@@ -1,9 +1,9 @@
-name: Release and Deploy to Development
+name: Release and Deploy to Production
 
 on:
   release:
     types:
-      - prereleased
+      - released
 
 jobs:
   build-and-push-image:
@@ -42,24 +42,25 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.ACTIONS_TOKEN }}
 
-      - name: Build development and Push to ghcr
+      - name: Build production and Push to ghcr
         uses: docker/build-push-action@v3
         with:
           context: .
-          file: Dockerfile.dev
+          file: Dockerfile.prod
           push: true
           tags: |
             ghcr.io/${{ github.repository }}:${{ env.tag }}
             ghcr.io/${{ github.repository }}:latest
 
-      - name: Deploy to test server
+      - name: Deploy to production server
         uses: appleboy/ssh-action@master
         with:
-          host: ${{ secrets.HOST }}
-          username: ${{ secrets.USERNAME }}
-          key: ${{ secrets.KEY }}
+          host: ${{ secrets.HOST_PROD }}
+          username: ${{ secrets.USERNAME_PROD }}
+          key: ${{ secrets.KEY_PROD }}
+          # docker compose v2
           script: |
             docker image prune -f
             docker pull ghcr.io/${{ github.repository }}:latest
-            docker-compose up -d
+            docker compose up -d
             docker ps

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,9 +1,9 @@
 name: Release and Deploy
 
 on:
-  push:
-    tags:
-      - "**"
+  release:
+    types:
+      - prereleased
 
 jobs:
   build-and-push-image:

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,0 +1,9 @@
+FROM openjdk:11
+
+VOLUME /tmp
+ENV TZ Asia/Seoul
+EXPOSE 8080
+ARG JAR_FILE=build/libs/ShareWork-0.0.1-SNAPSHOT.jar
+COPY ${JAR_FILE} app.jar
+
+ENTRYPOINT ["java", "-jar", "/app.jar", "--spring.profiles.active=prod"]

--- a/src/main/java/com/sharework/config/SwaggerConfig.java
+++ b/src/main/java/com/sharework/config/SwaggerConfig.java
@@ -1,8 +1,8 @@
 package com.sharework.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
 import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
@@ -12,13 +12,17 @@ import springfox.documentation.spring.web.plugins.Docket;
 
 @Configuration
 public class SwaggerConfig {
+
+    @Value("${spring.profiles.active:}")
+    private String profile;
+
     @Bean
     public Docket api() {
         return new Docket(DocumentationType.SWAGGER_2).useDefaultResponseMessages(false).select().apis(RequestHandlerSelectors.any()).paths(PathSelectors.any()).build().apiInfo(apiInfo());
     }
 
     private ApiInfo apiInfo() {
-        String description = "ShareWork팀 입니다.";
-        return new ApiInfoBuilder().title("SWAGGER TEST").description(description).version("1.0").build();
+        String description = "sharework-api " + profile + " 서버 입니다";
+        return new ApiInfoBuilder().title("ShareWork API").description(description).version("1.0").build();
     }
 }


### PR DESCRIPTION
- 운영 환경 CICD 추가합니다
- 트리거 방식을 릴리즈 타입에 따라 동작하도록 수정합니다
  - `prereleased` - 개발(테스트)서버, develop 브랜치
  - `released` - 운영(본)서버, main 브랜치
- 현재 개발 환경에서 복사를 하고 변경 사항은 다음과 같습니다
  - Dockerfile.prod 추가
  - 액션 시크릿 `*_PROD` 추가
- 스웨거 설명 부분에 서버 환경을 표시합니다