### PR TITLE
Fix slack alert missed for prod.

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -24,7 +24,7 @@
 
     <root level="INFO">
         <appender-ref ref="CONSOLE"/>
-        <springProfile name="dev">
+        <springProfile name="dev, prod">
             <appender-ref ref="ASYNC_SLACK"/>
         </springProfile>
     </root>


### PR DESCRIPTION
슬랙 채널 [sharework-api-errors](https://backcamp2023.slack.com/archives/C05U6NME47R) 에 운영환경도 추가합니다