### PR TITLE
Add scheme for AlarmRequest

### DIFF
--- a/src/main/java/com/sharework/request/model/AlarmRequest.java
+++ b/src/main/java/com/sharework/request/model/AlarmRequest.java
@@ -16,4 +16,7 @@ public class AlarmRequest {
 
     @ApiModelProperty(value = "알람 본문", example = "'[함정훈]' 님으로부터 구직 신청이 들어왔습니다.")
     private String body;
+
+    @ApiModelProperty(value = "알람 스킴")
+    private String scheme;
 }

--- a/src/main/java/com/sharework/service/AlarmService.java
+++ b/src/main/java/com/sharework/service/AlarmService.java
@@ -52,6 +52,7 @@ public class AlarmService {
                 .setTitle(request.getTitle())
                 .setBody(request.getBody())
                 .build())
+            .putData("scheme", request.getScheme())
             .setToken(request.getTargetFCMToken())
             .build();
 


### PR DESCRIPTION
- 클라팀 @hch-ang 요청으로, 사용자정의 메시지 또는 데이터 목적으로 'scheme' 필드를 추가합니다
- 참고
  - https://firebase.google.com/docs/cloud-messaging/send-message?hl=ko#send-messages-to-specific-devices
  - https://firebase.google.com/docs/cloud-messaging/ios/receive?hl=ko#interpreting_notification_message_payload