### PR TITLE
add getJobSimple id, groupstatus

### DIFF
--- a/src/main/java/com/sharework/response/model/application/GroupStatus.java
+++ b/src/main/java/com/sharework/response/model/application/GroupStatus.java
@@ -1,0 +1,13 @@
+package com.sharework.response.model.application;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@RequiredArgsConstructor
+public class GroupStatus {
+    private String name;
+    private int count;
+}

--- a/src/main/java/com/sharework/response/model/job/JobSimpleResponse.java
+++ b/src/main/java/com/sharework/response/model/job/JobSimpleResponse.java
@@ -1,6 +1,7 @@
 package com.sharework.response.model.job;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.sharework.response.model.application.GroupStatus;
 import com.sharework.response.model.meta.BasicMeta;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -23,7 +24,7 @@ public class JobSimpleResponse {
     @AllArgsConstructor
     public static class JobSimplePayload {
 
-        private JobSimple jobDetail;
+        private JobSimple jobOverviews;
     }
 
     @Getter
@@ -32,6 +33,8 @@ public class JobSimpleResponse {
     public static class JobSimple {
 
         private LocalDateTime endAt;
+        private long id;
+        private GroupStatus groupStatus;
         private int pay;
         private LocalDateTime startAt;
         private String status;

--- a/src/main/java/com/sharework/service/JobService.java
+++ b/src/main/java/com/sharework/service/JobService.java
@@ -106,7 +106,7 @@ public class JobService {
                 JobTypeEnum.CLOSED.name(),
                 JobTypeEnum.STARTED.name()
         );
-        com.sharework.response.model.application.GroupStatus status = new com.sharework.response.model.application.GroupStatus();
+        com.sharework.response.model.application.GroupStatus status = new com.sharework.response.model.application.GroupStatus();  // FIXME: refactor with GroupStatus I/F.
         if (Objects.equals(job.get().getStatus(), JobTypeEnum.COMPLETED.name())) {
             GroupStatus groupStatus = applicationDao.completedGroupStatus(job.get().getId());
 


### PR DESCRIPTION
- 클라팀과 논의 후 페이로드 필드명 수정을 하고 추가합니다 - `jobOverviews` `id` `groupstatus`
- groupstatus 는 기존 `ProceedingGroupStatus` `CompletedGroupStatus` 를 사용합니다. (추후 통합해서 사용할 수 있도록 수정 계획)
- 현재 groupstatus 가 Proceeding, Completed 이외의 상태에 대해서는 논의 되거나 정의되지 않아, 빈칸과 0 으로 정의합니다