### PR TITLE
Refactor schedule for updateEndAtApplicationStatus

### DIFF
--- a/src/main/java/com/sharework/dao/ApplicationDao.java
+++ b/src/main/java/com/sharework/dao/ApplicationDao.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -68,6 +69,7 @@ public interface ApplicationDao extends JpaRepository<Application, Long> {
     @Query(value = "SELECT * FROM application WHERE end_at <= now() and status = 'HIRED'", nativeQuery = true)
     List<Application> getEndTimeoutHiredApplication();
 
+    List<Application> findByEndAtLessThanEqualAndStatusEqualsOrderByEndAtAsc(LocalDateTime endAt, String status);
 
     @Query(value = "SELECT sum(date_part('hour', app.end_at-app.start_at)) as hour FROM application app WHERE user_id =  :userId and job_id in(select jt.job_id from job_tag jt where jt.contents = :contents)", nativeQuery = true)
     int countByUserIdAndTagContents(@Param("userId") long userId, @Param("contents") String contents);

--- a/src/main/java/com/sharework/scheduler/Schedule.java
+++ b/src/main/java/com/sharework/scheduler/Schedule.java
@@ -52,15 +52,21 @@ public class Schedule {
         //application schedule
 
         //status가 appied이며, 현재시간이 마감시간을 넘겼다면 failed
-        List<Application> applicationAppliedList = applicationDao.getEndTimeoutAppliedApplication();
+        List<Application> applicationAppliedList = applicationDao.findByEndAtLessThanEqualAndStatusEqualsOrderByEndAtAsc(
+                LocalDateTime.now(), ApplicationTypeEnum.APPLIED.name()
+        );
         applicationAppliedList.forEach(item -> item.setStatus(ApplicationTypeEnum.FAILED.name()));
 
         //status가 hired_request이며, 현재시간이 마감시간을 넘겼다면 rejected
-        List<Application> applicationHiredRequestList = applicationDao.getEndTimeoutHiredRequestApplication();
+        List<Application> applicationHiredRequestList = applicationDao.findByEndAtLessThanEqualAndStatusEqualsOrderByEndAtAsc(
+                LocalDateTime.now(), ApplicationTypeEnum.HIRED_REQUEST.name()
+        );
         applicationHiredRequestList.forEach(item -> item.setStatus(ApplicationTypeEnum.REJECTED.name()));
 
         //status가 hired_approved, 현재시간이 마감시간을 넘겼다면 completed
-        List<Application> applicationHiredApprovedList = applicationDao.getEndTimeoutHiredApprovedApplication();
+        List<Application> applicationHiredApprovedList = applicationDao.findByEndAtLessThanEqualAndStatusEqualsOrderByEndAtAsc(
+                LocalDateTime.now(), ApplicationTypeEnum.HIRED_APPROVED.name()
+        );
         applicationHiredApprovedList.forEach(item -> {
             item.setStatus(ApplicationTypeEnum.COMPLETED.name());
 
@@ -82,7 +88,8 @@ public class Schedule {
 
 
         //status가 hired이며, 현재시간이 마감시간을 넘겼다면 noshow
-        List<Application> applicationHiredList = applicationDao.getEndTimeoutHiredApplication();
+        List<Application> applicationHiredList = applicationDao.findByEndAtLessThanEqualAndStatusEqualsOrderByEndAtAsc(
+                LocalDateTime.now(), ApplicationTypeEnum.HIRED.name());
         applicationHiredList.forEach(item -> item.setStatus(ApplicationTypeEnum.NO_SHOW.name()));
     }
 

--- a/src/main/java/com/sharework/scheduler/Schedule.java
+++ b/src/main/java/com/sharework/scheduler/Schedule.java
@@ -48,19 +48,7 @@ public class Schedule {
         });
     }
 
-
-    private void endAtAutoUpdate() {
-        //job schedule
-        //status가 started이며, 현재시간이 마감시간을 넘겼다면 COMPLTED 시간으로 돈 계산하여 application_total_payment에 저장한다.
-        List<Job> jobStartedList = jobDao.getEndTimeoutStartedJobs();
-        jobStartedList.forEach(item -> {
-            item.setStatus(JobTypeEnum.COMPLETED.name());
-        });
-
-        //status가 open,closed이며, 현재시간이 마감시간을 넘겼다면 falied
-        List<Job> jobOpenAndClosedList = jobDao.getEndTimeoutOpenAndClosedJobs();
-        jobOpenAndClosedList.forEach(item -> item.setStatus(JobTypeEnum.FAILED.name()));
-
+    private void updateEndAtApplicationStatus() {
         //application schedule
 
         //status가 appied이며, 현재시간이 마감시간을 넘겼다면 failed
@@ -96,5 +84,20 @@ public class Schedule {
         //status가 hired이며, 현재시간이 마감시간을 넘겼다면 noshow
         List<Application> applicationHiredList = applicationDao.getEndTimeoutHiredApplication();
         applicationHiredList.forEach(item -> item.setStatus(ApplicationTypeEnum.NO_SHOW.name()));
+    }
+
+    private void endAtAutoUpdate() {
+        //job schedule
+        //status가 started이며, 현재시간이 마감시간을 넘겼다면 COMPLTED 시간으로 돈 계산하여 application_total_payment에 저장한다.
+        List<Job> jobStartedList = jobDao.getEndTimeoutStartedJobs();
+        jobStartedList.forEach(item -> {
+            item.setStatus(JobTypeEnum.COMPLETED.name());
+        });
+
+        //status가 open,closed이며, 현재시간이 마감시간을 넘겼다면 falied
+        List<Job> jobOpenAndClosedList = jobDao.getEndTimeoutOpenAndClosedJobs();
+        jobOpenAndClosedList.forEach(item -> item.setStatus(JobTypeEnum.FAILED.name()));
+
+        updateEndAtApplicationStatus();
     }
 }


### PR DESCRIPTION
- 스케쥴러 endAtAutoUpdate 메소드에 대해서 리펙토링 합니다
  - Application 부분만, 별도 메소드 _updateEndAtApplicationStatus_, 분리하고,
  - JPA 인터페이스 _findByEndAtLessThanEqualAndStatusEqualsOrderByEndAtAsc_, 추가하여 정리합니다