### PR TITLE
db: fix user_alarm sequence and restart 50

### DIFF
--- a/src/main/resources/db/migration/V1_0_2__create_seq_user_alarm.sql
+++ b/src/main/resources/db/migration/V1_0_2__create_seq_user_alarm.sql
@@ -1,0 +1,22 @@
+-- Drop the existing default value
+ALTER TABLE user_alarm
+    ALTER COLUMN id DROP DEFAULT;
+
+-- Create user_alarm_id_seq
+CREATE SEQUENCE user_alarm_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+ALTER TABLE user_alarm_id_seq
+    OWNER TO sharework;
+
+ALTER SEQUENCE user_alarm_id_seq OWNED BY user_alarm.id;
+
+ALTER TABLE ONLY user_alarm
+    ALTER COLUMN id SET DEFAULT nextval('user_alarm_id_seq'::regclass);
+
+-- Alter the sequence to start from 50
+ALTER SEQUENCE user_alarm_id_seq RESTART WITH 50;


### PR DESCRIPTION
- **user_alarm** 테이블의 id 컬럼 시퀀스를 수정합니다
- `\d+` 명령어를 이용한 user_alarm 테이블 상세 정보
```
sharework_production=# \d+ user_alarm
                                                                   Table "public.user_alarm"
   Column   |            Type             | Collation | Nullable |                Default                | Storage  | Compression | Stats target | Description
------------+-----------------------------+-----------+----------+---------------------------------------+----------+-------------+--------------+-------------
 id         | bigint                      |           | not null | nextval('user_rate_id_seq'::regclass) | plain    |             |              |
 fcm_token  | character varying(255)      |           | not null |                                       | extended |             |              |
 user_id    | bigint                      |           | not null |                                       | plain    |             |              |
 updated_at | timestamp without time zone |           |          |                                       | plain    |             |              |
Indexes:
    "user_alarm_pkey" PRIMARY KEY, btree (id)
Access method: heap
```
- 기존에 잘못 설정된 Default 부분에 _user_rate_id_seq_  를 제거하고, 50 부터 시작하는 _user_alarm_id_seq_ 를 추가하여 적용합니다
  - 현재 개발 및 운영 DB의 user_alarm 테이블의 데이터 인덱스가 30번 정도까지 차있는 상태 입니다. 
  - 넉넉히 50 부터 시작하는걸로 적용했습니다